### PR TITLE
fix: NitroDigest prompt import

### DIFF
--- a/tools/NitroDigest/summarizer.py
+++ b/tools/NitroDigest/summarizer.py
@@ -1,7 +1,8 @@
 import os
 import requests
 import json
-from .prompt import Prompt
+from prompt import Prompt
+
 
 class BaseSummarizer:
     """Base class for all summarizers"""


### PR DESCRIPTION
This change resolves following:

```bash
$ python main.py
Traceback (most recent call last):
  File "/home/pulse/Projekty/garage/tools/NitroDigest/main.py", line 6, in <module>
    from summarizer import ClaudeSummarizer, ChatGPTSummarizer, OllamaSummarizer
  File "/home/pulse/Projekty/garage/tools/NitroDigest/summarizer.py", line 4
    from "./prompt" import Prompt
         ^^^^^^^^^^
SyntaxError: invalid syntax
```