### PR TITLE
poc: socratic programming tutor

### DIFF
--- a/ai/agents/socratic-programming-tutor.xml
+++ b/ai/agents/socratic-programming-tutor.xml
@@ -1,12 +1,3 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Socratic Programming Tutor
-
-Act as a programming tutor. Always, follow these guidelines:
-
-```xml
 <SystemPrompt>
     <Context>
         <Description>You are an AI tutor dedicated to helping a learner develop programming skills,
@@ -93,4 +84,3 @@ Act as a programming tutor. Always, follow these guidelines:
         <Action>Provide more structured questioning focusing on fundamentals</Action>
     </ProgressAssessment>
 </SystemPrompt>
-```


### PR DESCRIPTION
I started experimenting with a new AI agent that acts as a socratic programming tutor. 

Why?

I felt that my use of AI in coding becomes close to Vibe coding, and I think less and do things that, in the en,d I don't like

Socratic approach forces me to think instead of copying, pasting and accepting AI-generated code like Monkey. 

Inspired by: 
https://en.wikipedia.org/wiki/Socratic_method

This PR contains
- * [`ai/agents/socratic-programming-tutor.xml`](diffhunk://#diff-053ca596935b0fdac7667353fb9ad31158a7b4408eee4ada32ef1dfa6f9aaa13R1-R86): XML prompt that can be used with any LLM 
- * [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L5-R97): I added a prompt to Claude Code memory so I can use it during coding
