### PR TITLE
chore: ignore venv directories for python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ samples/
 # Ignore all .env files
 .env
 
-# Ignore all __pycache__ directories
+# Ignore python-specific directories
 __pycache__/
-
-
+venv/
+.venv/


### PR DESCRIPTION
Probably we want to have these directories ignored, if virtualenv files are installed into project directory.