### PR TITLE
fix: increased ctx length in Ollama Modelfile

### DIFF
--- a/tools/NitroDigest/.env.example
+++ b/tools/NitroDigest/.env.example
@@ -12,7 +12,7 @@ CHATGPT_API_KEY=your_chatgpt_api_key
 
 # Ollama configuration
 OLLAMA_API_URL=http://localhost:11434
-OLLAMA_MODEL=mistral
+OLLAMA_MODEL=nitroModel
 
 # Summarizer selection (claude, chatgpt, ollama)
 ACTIVE_SUMMARIZER=ollama

--- a/tools/NitroDigest/ollama/Modelfile
+++ b/tools/NitroDigest/ollama/Modelfile
@@ -1,3 +1,4 @@
 FROM llama2:latest
 
 PARAMETER temperature 0.5
+PARAMETER num_ctx 4096


### PR DESCRIPTION
Closes #66 

Increased context limit to 4096

Note:
- Increasing context limit can decrease model qualityu
- 4096 limit needs 16 GB of RAM 🫨 
- A better approach to handling long newsletters will be using chunked prompts
- created issue for that: #97