### PR TITLE
feat(#69). Added simple fixed backoff retry mechanism

### DIFF
--- a/tools/NitroDigest/summary_writer.py
+++ b/tools/NitroDigest/summary_writer.py
@@ -62,7 +62,7 @@ class SummaryWriter:
                 date_match = re.search(
                     r'\d{1,2}\s+\w+\s+\d{4}', metadata['date'])
                 if date_match:
-                    date_str = date_match.group(0).replace(' ', '-')
+                    date_str = date_match.group(0).replace(' ', '-').lower()
             except:
                 pass
 

--- a/tools/NitroDigest/utils.py
+++ b/tools/NitroDigest/utils.py
@@ -15,16 +15,15 @@ class RetryStatusCode(Enum):
 
 def retry(func):
     """
-    Retries a function 2 times with 10-second delays on HTTP status codes
-    408, 409, 429, 500, 502, 503, 504 or request exceptions.
+    Retries a function up to 2 times (for a total of 3 attempts, including the initial attempt)
+    with 10-second delays on HTTP status codes 408, 409, 429, 500, 502, 503, 504 or request exceptions.
     """
     def wrapper(*args, **kwargs):
-        retries = 2
+        max_retries = 2
         delay_seconds = 10
         retry_status_codes = {code.value for code in RetryStatusCode}
 
-        for attempt in range(retries + 1):
-            try:
+        for attempt in range(max_retries + 1):
                 response = func(*args, **kwargs)
 
                 if response.status_code not in retry_status_codes:

--- a/tools/NitroDigest/utils.py
+++ b/tools/NitroDigest/utils.py
@@ -1,0 +1,44 @@
+import time
+import requests
+from enum import Enum
+
+
+class RetryStatusCode(Enum):
+    REQUEST_TIMEOUT = 408
+    CONFLICT = 409
+    TOO_MANY_REQUESTS = 429
+    INTERNAL_SERVER_ERROR = 500
+    BAD_GATEWAY = 502
+    SERVICE_UNAVAILABLE = 503
+    GATEWAY_TIMEOUT = 504
+
+
+def retry(func):
+    """
+    Retries a function 2 times with 10-second delays on HTTP status codes
+    408, 409, 429, 500, 502, 503, 504 or request exceptions.
+    """
+    def wrapper(*args, **kwargs):
+        retries = 2
+        delay_seconds = 10
+        retry_status_codes = {code.value for code in RetryStatusCode}
+
+        for attempt in range(retries + 1):
+            try:
+                response = func(*args, **kwargs)
+
+                if response.status_code not in retry_status_codes:
+                    return response
+
+                if attempt == retries:
+                    return response
+
+            except requests.exceptions.RequestException as e:
+                if attempt == retries:
+                    raise
+
+            print(f"Attempt {attempt + 1} failed")
+            time.sleep(delay_seconds)
+            print("Retrying...")
+
+    return wrapper


### PR DESCRIPTION
Closes #69 

I added a new retry util. It's really simple, but enough for now. I didn't use a library like `tenacity` to avoid adding a new dependency to the project. 

If in the future we would like to have a more flexible solution, then we will use a library.

Also, I fixed one small issue in the summary_writer test.

Last, I changed timeout values. Ollama needs at least 2 minutes to process a request locally.