### PR TITLE
refactor(#102): changed prompt, added two steps summarizing for ollama

### DIFF
--- a/tools/NitroDigest/README.md
+++ b/tools/NitroDigest/README.md
@@ -6,11 +6,14 @@ A Python tool for automatically summarizing email newsletters using AI.
 
 - Connect to IMAP email servers to retrieve unread newsletters
 - Extract text content from HTML emails
+- Two-step summarization process:
+  1. Initial summary with key points and links
+  2. Refined summary with single-sentence bullets and links
 - Summarize content using various AI models:
   - Claude (Anthropic)
   - ChatGPT (OpenAI)
   - Ollama (local models)
-- Save summaries as Markdown files with YAML frontmatter
+- Save all summaries in a single combined Markdown file with YAML frontmatter
 - Command-line interface with various options
 
 ## Requirements
@@ -273,3 +276,34 @@ Don't worry if you're not sure about something - we're here to help! Just open a
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Output Format
+
+Summaries are saved in a single `combined_summaries.md` file in your specified output directory. Each summary includes:
+
+- YAML frontmatter with metadata (title, source, date, etc.)
+- The refined summary with single-sentence bullets and links
+- Separators between different summaries
+
+Example output structure:
+
+```markdown
+# Combined Newsletter Summaries
+
+---
+
+title: Tech Weekly Newsletter
+source: tech@example.com
+date: 2024-03-20
+email_id: 12345
+summary_date: 2024-03-20 14:30:00
+
+---
+
+- OpenAI released GPT-5 with improved reasoning [link]
+- Apple announced M3 Pro chips with better performance [link]
+
+---
+
+// ... next summary ...
+```

--- a/tools/NitroDigest/ollama/Modelfile-llama3
+++ b/tools/NitroDigest/ollama/Modelfile-llama3
@@ -1,0 +1,4 @@
+FROM llama3.2-vision:11b
+
+PARAMETER temperature 0.5
+PARAMETER num_ctx 8192

--- a/tools/NitroDigest/prompt.py
+++ b/tools/NitroDigest/prompt.py
@@ -4,15 +4,19 @@ import os
 class Prompt:
     """Class to handle prompt template and formatting"""
 
-    def __init__(self, template_path=None):
-        """Initialize with optional custom template path"""
+    def __init__(self, template_path=None, second_template_path=None):
+        """Initialize with optional custom template paths"""
         if template_path is None:
             template_path = os.path.join(
                 os.path.dirname(__file__), 'prompt_template.txt')
+        if second_template_path is None:
+            second_template_path = os.path.join(
+                os.path.dirname(__file__), 'prompt_template2.txt')
         self.template_path = template_path
+        self.second_template_path = second_template_path
 
     def format(self, text, metadata=None):
-        """Format the prompt with given text and metadata"""
+        """Format the first prompt with given text and metadata"""
         # Read the template file
         with open(self.template_path, 'r') as f:
             prompt = f.read()
@@ -28,6 +32,17 @@ class Prompt:
 
         # Replace placeholders
         prompt = prompt.replace('{metadata}', metadata_str)
+        prompt = prompt.replace('{text}', text)
+
+        return prompt
+
+    def format_second(self, text):
+        """Format the second prompt with given text"""
+        # Read the second template file
+        with open(self.second_template_path, 'r') as f:
+            prompt = f.read()
+
+        # Replace placeholder
         prompt = prompt.replace('{text}', text)
 
         return prompt

--- a/tools/NitroDigest/prompt_template.txt
+++ b/tools/NitroDigest/prompt_template.txt
@@ -2,24 +2,13 @@ You are a newsletter summarizer assistant.
 
 {metadata}
 
-Analyze and summarize the following email in English, extracting only the most valuable information.{partHeader}
-
-Format requirements:
-1. Start with a level 1 header containing the email subject
-2. Include a simple TLDR summary at the top with bullet points showing important information (include relevant links)
-3. Present main points as a bullet list, with sub-bullets only for essential supporting details
-4. For action items, create a separate 'Action Items' section with checkboxes
-5. If deadlines/dates are mentioned, list them in a 'Key Dates' section
-6. Use bold formatting for truly critical information only
-7. Preserve all important links in Markdown format
-8. Keep the summary extremely concise, focusing only on valuable content
-
-Important filtering instructions:
-- Aggressively filter out all promotional and marketing content that doesn't provide substantial information
-- Ignore boilerplate text, footers, disclaimers, and unsubscribe information
-- Omit generic greetings and sign-offs
-- Focus exclusively on actionable and informative content
-- If the email is primarily marketing with little substance, simply note this fact
+Summarize the following newsletter into a TL;DR list.
+Each bullet should be a single sentence summarizing a key point.
+For each point, find and include the most relevant URL from the original text.
+Do not create placeholder links or use "https://link".
+Only use actual URLs that exist in the original text.
+Do not use disclaimers or enumeration.
+Limit the summary to 300 characters.
 
 Newsletter content:
 

--- a/tools/NitroDigest/prompt_template2.txt
+++ b/tools/NitroDigest/prompt_template2.txt
@@ -1,0 +1,3 @@
+Rewrite the following TL;DR so each bullet is a single sentence with a link, and remove any disclaimers or extra text:
+
+{text}

--- a/tools/NitroDigest/summary_writer.py
+++ b/tools/NitroDigest/summary_writer.py
@@ -17,36 +17,51 @@ class SummaryWriter:
             os.makedirs(self.output_dir)
 
     def write_summary(self, summary, metadata):
-        """Write a summary to a markdown file with YAML frontmatter"""
+        """Write a summary to the combined markdown file
+        with YAML frontmatter"""
         if not summary or not metadata:
             return None
 
         try:
-            # Generate filename from subject or date
-            filename = self._generate_filename(metadata)
-            filepath = os.path.join(self.output_dir, filename)
+            # Get current date for filename
+            current_date = datetime.now().strftime("%Y-%m-%d")
+            combined_file = os.path.join(
+                self.output_dir, f"combined_summaries_{current_date}.md")
+
+            # Initialize file if it doesn't exist
+            if not os.path.exists(combined_file):
+                with open(combined_file, 'w', encoding='utf-8') as f:
+                    f.write(
+                        "# Combined Newsletter Summaries - "
+                        f"{current_date}\n\n")
 
             # Prepare YAML frontmatter
             frontmatter = {
                 'title': metadata.get('subject', 'Untitled Newsletter'),
                 'source': metadata.get('from', 'Unknown'),
-                'date': metadata.get('date', datetime.now().strftime("%Y-%m-%d")),
+                'date': metadata.get(
+                    'date', datetime.now().strftime("%Y-%m-%d")),
                 'email_id': metadata.get('id', ''),
                 'summary_date': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             }
 
-            # Write to file with YAML frontmatter
-            with open(filepath, 'w', encoding='utf-8') as f:
+            # Append to combined file
+            with open(combined_file, 'a', encoding='utf-8') as f:
                 f.write('---\n')
-                yaml.dump(frontmatter, f, default_flow_style=False,
-                          allow_unicode=True)
+                yaml.dump(
+                    frontmatter,
+                    f,
+                    default_flow_style=False,
+                    allow_unicode=True
+                )
                 f.write('---\n\n')
                 f.write(summary)
+                f.write('\n\n---\n\n')
 
-            print(f"Summary written to {filepath}")
-            return filepath
+            print(f"Summary added to {combined_file}")
+            return combined_file
 
-        except Exception as e:
+        except (IOError, yaml.YAMLError) as e:
             print(f"Error writing summary file: {e}")
             return None
 
@@ -58,12 +73,12 @@ class SummaryWriter:
         # Try to parse date from metadata
         if 'date' in metadata:
             try:
-                # This is a simple approach - more sophisticated date parsing might be needed
+                # Simple date parsing approach
                 date_match = re.search(
                     r'\d{1,2}\s+\w+\s+\d{4}', metadata['date'])
                 if date_match:
                     date_str = date_match.group(0).replace(' ', '-').lower()
-            except:
+            except re.error:
                 pass
 
         if not date_str:
@@ -87,8 +102,10 @@ def test_summary_writer():
 - The new model processes images, audio, and text with higher accuracy
 
 ## Industry News
-- Apple announced M3 Pro chips with 40% better performance and lower power consumption
-- Google Cloud introduced new serverless database options for enterprise customers
+- Apple announced M3 Pro chips with 40% better performance and lower power
+consumption
+- Google Cloud introduced new serverless database options for enterprise
+customers
 
 ## Upcoming Events
 - Annual Developer Conference on May 15-17 in San Francisco

--- a/tools/NitroDigest/summary_writer.py
+++ b/tools/NitroDigest/summary_writer.py
@@ -2,6 +2,7 @@ import os
 import yaml
 from datetime import datetime
 import re
+from summarizer.utils.logging import get_logger
 
 
 class SummaryWriter:
@@ -11,6 +12,7 @@ class SummaryWriter:
         """Initialize the summary writer"""
         self.output_dir = output_dir or os.environ.get(
             "SUMMARIES_PATH", "summaries")
+        self.logger = get_logger(__name__)
 
         # Create output directory if it doesn't exist
         if not os.path.exists(self.output_dir):
@@ -58,11 +60,11 @@ class SummaryWriter:
                 f.write(summary)
                 f.write('\n\n---\n\n')
 
-            print(f"Summary added to {combined_file}")
+            self.logger.info(f"Summary added to {combined_file}")
             return combined_file
 
         except (IOError, yaml.YAMLError) as e:
-            print(f"Error writing summary file: {e}")
+            self.logger.error(f"Error writing summary file: {e}")
             return None
 
     def _generate_filename(self, metadata):


### PR DESCRIPTION
Closes #102 

Improvements for summarizing. 


## Prompt changes 

Changed prompt. Prompt descibre how to summarize an email. An expected summary is like typical TLDR - list with items. 

## Two steps summarizing process

Added two steps summarizing process. 

1. First prompt and request - general summarizing
2. Second prompt and request -  experimental. Why? Because results from the first request sometimes are not ideal. Looks like Ollama ignores instructions related to formatting. 

## Save summary into one file

From now summary is saved to one file instead of file per email

## Docus updates:
- Updated the README 


## Model Configuration:
* Added a new `Modelfile-llama3` configuration for the `llama3.2-vision` model (for experimenting)