### PR TITLE
feat(#22): added support for custom prompt via  args and configuration

### DIFF
--- a/tools/NitroDigest/README.md
+++ b/tools/NitroDigest/README.md
@@ -236,7 +236,40 @@ Available arguments:
 - `--password`: Email password (overrides config)
 - `--server`: IMAP server (overrides config)
 - `--folder`: Email folder to process
-- `--timeout`: time in seconds that summarizer waits for response from LLM
+- `--timeout`: Time in seconds that summarizer waits for response from LLM
+- `--prompt-file`: Path to custom prompt template file (overrides config)
+- `--prompt`: Direct prompt content (overrides both config and prompt-file)
+
+### Prompt Configuration
+
+You can specify the prompt template in three ways:
+
+1. In the config.json file:
+
+```json
+{
+  "summarizer": {
+    "prompt_file": "prompt_template.txt"
+  }
+}
+```
+
+2. Using the `--prompt-file` argument:
+
+```bash
+python main.py --prompt-file custom_prompt.txt
+```
+
+3. Passing the prompt content directly:
+
+```bash
+python main.py --prompt "$(cat my_awesome_prompt.txt)"
+```
+
+The prompt template should contain placeholders:
+
+- `{metadata}`: For email metadata (from, subject, date)
+- `{text}`: For the email content to be summarized
 
 ## Testing
 

--- a/tools/NitroDigest/README.md
+++ b/tools/NitroDigest/README.md
@@ -8,7 +8,7 @@ A Python tool for automatically summarizing email newsletters using AI.
 - Extract text content from HTML emails
 - Two-step summarization process:
   1. Initial summary with key points and links
-  2. Refined summary with single-sentence bullets and links
+  2. Refined summary with single-sentence bullets and links (Note: in the current implementation this step is disabled)
 - Summarize content using various AI models:
   - Claude (Anthropic)
   - ChatGPT (OpenAI)

--- a/tools/NitroDigest/config.py
+++ b/tools/NitroDigest/config.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 from enum import Enum
@@ -32,6 +33,7 @@ class SummarizerConfig:
     base_url: str = "http://localhost:11434"
     api_key: Optional[str] = None
     timeout: int = 300
+    prompt_file: Optional[str] = None
 
     def validate(self) -> None:
         if self.type == SummarizerType.OLLAMA and not self.model:
@@ -41,6 +43,10 @@ class SummarizerConfig:
             raise ValueError("API key is required for Claude and ChatGPT")
         if self.timeout <= 0:
             raise ValueError("Timeout must be a positive number")
+        if (self.prompt_file and
+                not os.path.exists(self.prompt_file)):
+            raise ValueError(
+                f"Prompt file not found: {self.prompt_file}")
 
 
 @dataclass
@@ -73,6 +79,10 @@ class Config:
         if (self.summarizer.type == SummarizerType.OLLAMA and
                 not self.summarizer.model):
             raise ValueError("Model is required for Ollama")
+        if (self.summarizer.prompt_file and
+                not os.path.exists(self.summarizer.prompt_file)):
+            raise ValueError(
+                f"Prompt file not found: {self.summarizer.prompt_file}")
 
         self.email.validate()
         self.summarizer.validate()
@@ -104,7 +114,8 @@ class Config:
             model=model,
             base_url=summarizer_data.get('base_url', 'http://localhost:11434'),
             api_key=summarizer_data.get('api_key'),
-            timeout=summarizer_data.get('timeout', 300)
+            timeout=summarizer_data.get('timeout', 300),
+            prompt_file=summarizer_data.get('prompt_file')
         )
 
         return cls(
@@ -145,6 +156,8 @@ class Config:
 
         if self.summarizer.api_key:
             data['summarizer']['api_key'] = self.summarizer.api_key
+        if self.summarizer.prompt_file:
+            data['summarizer']['prompt_file'] = self.summarizer.prompt_file
 
         return data
 

--- a/tools/NitroDigest/prompt.py
+++ b/tools/NitroDigest/prompt.py
@@ -15,6 +15,12 @@ class Prompt:
         self.template_path = template_path
         self.second_template_path = second_template_path
 
+    def set_template_path(self, path: str) -> None:
+        """Set a custom template path"""
+        if not os.path.exists(path):
+            raise ValueError(f"Template file not found: {path}")
+        self.template_path = path
+
     def format(self, text, metadata=None):
         """Format the first prompt with given text and metadata"""
         # Read the template file

--- a/tools/NitroDigest/summarizer/providers/claude.py
+++ b/tools/NitroDigest/summarizer/providers/claude.py
@@ -24,12 +24,15 @@ class ClaudeSummarizer(BaseSummarizer):
         self,
         api_key: str,
         model: str = "claude-3-haiku-20240307",
-        timeout: int = 300
+        timeout: int = 300,
+        prompt_file: Optional[str] = None
     ):
         super().__init__()
         self.api_key = api_key
         self.model = model
         self.timeout = timeout
+        if prompt_file:
+            self.prompt.set_template_path(prompt_file)
 
     def summarize(
         self,

--- a/tools/NitroDigest/summarizer/providers/ollama.py
+++ b/tools/NitroDigest/summarizer/providers/ollama.py
@@ -77,17 +77,19 @@ class OllamaSummarizer(BaseSummarizer):
             response_data = response.json()
             first_summary = response_data["response"]
 
-            # Second summarization
-            second_prompt = self.prompt.format_second(first_summary)
-            data = self._prepare_request_data(second_prompt)
+            # commented out for now to simplify
+            # the process for debugging purposes
+            # # Second summarization
+            # second_prompt = self.prompt.format_second(first_summary)
+            # data = self._prepare_request_data(second_prompt)
 
-            self.logger.info(
-                f"Sending second request to Ollama API "
-                f"using model {self.model}")
-            response = self.call_ollama_api(headers, data)
-            self._check_response_status(response)
-            response_data = response.json()
-            final_summary = response_data["response"]
+            # self.logger.info(
+            #     f"Sending second request to Ollama API "
+            #     f"using model {self.model}")
+            # response = self.call_ollama_api(headers, data)
+            # self._check_response_status(response)
+            # response_data = response.json()
+            # final_summary = response_data["response"]
 
             tokens_used = 0
             if "eval_count" in response_data:
@@ -95,7 +97,7 @@ class OllamaSummarizer(BaseSummarizer):
 
             return SummaryResult(
                 status=ModelStatus.SUCCESS,
-                summary=final_summary,
+                summary=first_summary,
                 model_used=self.model,
                 tokens_used=tokens_used,
                 metadata={"api_response": response_data}

--- a/tools/NitroDigest/summarizer/providers/ollama.py
+++ b/tools/NitroDigest/summarizer/providers/ollama.py
@@ -25,12 +25,16 @@ class OllamaSummarizer(BaseSummarizer):
         self,
         model: str = "mistral",
         base_url: str = "http://localhost:11434",
-        timeout: int = 300
+        timeout: int = 300,
+        prompt_file: Optional[str] = None
     ):
         super().__init__()
         self.model = model
         self.base_url = base_url.rstrip('/')
         self.timeout = timeout
+
+        if prompt_file:
+            self.prompt.set_template_path(prompt_file)
 
         # Verify Ollama is available
         self._verify_ollama_availability()

--- a/tools/NitroDigest/summarizer/providers/openai.py
+++ b/tools/NitroDigest/summarizer/providers/openai.py
@@ -24,12 +24,15 @@ class ChatGPTSummarizer(BaseSummarizer):
         self,
         api_key: str,
         model: str = "gpt-3.5-turbo",
-        timeout: int = 300
+        timeout: int = 300,
+        prompt_file: Optional[str] = None
     ):
         super().__init__()
         self.api_key = api_key
         self.model = model
         self.timeout = timeout
+        if prompt_file:
+            self.prompt.set_template_path(prompt_file)
 
     def summarize(
         self,

--- a/tools/NitroDigest/summary_writer.py
+++ b/tools/NitroDigest/summary_writer.py
@@ -28,7 +28,9 @@ class SummaryWriter:
             # Get current date for filename
             current_date = datetime.now().strftime("%Y-%m-%d")
             combined_file = os.path.join(
-                self.output_dir, f"combined_summaries_{current_date}.md")
+                self.output_dir,
+                f"combined_summaries_{current_date}_{os.urandom(4).hex()}.md"
+            )
 
             # Initialize file if it doesn't exist
             if not os.path.exists(combined_file):


### PR DESCRIPTION
From now on, it's possible to specify a prompt file path in the config: 

```json
{
  "summarizer": {
    "prompt_file": "prompt_template.txt"
  }
}
```
This value can be overwritten by  the `--prompt-file` argument when running the tool:

```bash
python main.py-- prompt-file custom_prompt.txt
```

Also is possible to pass the prompt directly as text by the `--prompt` argument:

```bash
python main.py --prompt "$(cat my_awesome_prompt.txt)"
```

Note: besides this change, I commented experimental two-step prompt feature in the Ollama provider. I wanted to simplify the flow for now and fix the main issues with Ollama, like truncated prompts, performance issues. When I handle this groundwork, I will go back to experimenting withthe  two-step prompt.