### PR TITLE
fix: fixed issues wit nltk and logs printing

### DIFF
--- a/nitrodigest/main.py
+++ b/nitrodigest/main.py
@@ -182,7 +182,7 @@ def process_directory(directory_path, summarizer):
                 file_count += 1
 
     print(
-        f"Directory processing complete: {success_count} of {file_count} files processed successfully")
+        f"Directory processing complete: {success_count} of {file_count} files processed successfully", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/nitrodigest/summarizer/utils/token_budget_segmenter.py
+++ b/nitrodigest/summarizer/utils/token_budget_segmenter.py
@@ -1,10 +1,6 @@
 import nltk
 from typing import Optional, Dict, Any
-
-try:
-    nltk.data.find('tokenizers/punkt')
-except LookupError:
-    nltk.download('punkt')
+nltk.download('punkt_tab')
 
 """
  Split text to chunks based on token budget


### PR DESCRIPTION
Simplified logic responsible for downloading nltk data. Try/except is not needed because when package is already downloaded,
it will be not downloaded again so just `nltk.download()` is enough.

Also changed 'punkt' to 'punkt_tab' following to error I saw in the console.

Besides, fixed small issue with one log that was printed to stdout, but should be printend to stderr