### PR TITLE
fix: fixed links formats

### DIFF
--- a/Atlas/Books.md
+++ b/Atlas/Books.md
@@ -2,4 +2,4 @@ Here I list books I read and used in my learning journey.
 
 ## Cryptography
 
-- [[Cryptography and network security principles and practice (fifth edition) by William Stallings]]
+- [Cryptography and network security principles and practice (fifth edition) by William Stallings](Cryptography%20and%20network%20security%20principles%20and%20practice%20(fifth%20edition)%20by%20William%20Stallings.md)

--- a/Blog/4. Historical cryptography algorithms.md
+++ b/Blog/4. Historical cryptography algorithms.md
@@ -5,7 +5,7 @@ title: Historical cryptography algorithms
 
 *Last updated: 22/03/2025*
 
-My first task on the [[Cybersecurity learning roadmap]] course at studies was about experimenting with historical cryptography algorithms.
+My first task on the [Cybersecurity learning roadmap](Cybersecurity%20learning%20roadmap.md) course at studies was about experimenting with historical cryptography algorithms.
 
 I was sitting in the computer room, it was quite stuffy, and around me were 30 other students. It was the third class of the day. The lecturer came in, who looked like a rather strict gentleman. He explained to us briefly what the course would look like and what the rules were for passing.
 
@@ -59,10 +59,10 @@ In the scope of task I had: *Cesar*, *Vigenere*, *Hill* and *XOR*. Let's take a 
 
 ### Caesar's [[Cipher]]
 
-It's one of the oldest and simplest [[Encryption]] algorithm invented (or at least associated with) Julius Caesar.
+It's one of the oldest and simplest  [Encryption](Encryption.md) algorithm invented (or at least associated with) Julius Caesar.
 
 Cesar used in in around 58 BC. How it worked? It scrambled a message by shifting its letters.
-Technically speaking is a [[Monoalphabetic rotation ciphers]] it shifts letters by 3, but there is also a variant called `ROT-13` that shifts letters by 13.
+Technically speaking is a [Monoalphabetic rotation ciphers](Monoalphabetic%20rotation%20ciphers.md) it shifts letters by 3, but there is also a variant called `ROT-13` that shifts letters by 13.
 
 I implemented the Caesar cipher in C# for learning purposes.
 
@@ -99,12 +99,12 @@ flowchart TD
 
 ### Vigenère cipher
 
-It's a [[polyalphabetic substitution cipher]] which uses a keyword to encrypt and decrypt messages.
+It's a [polyalphabetic substitution cipher](polyalphabetic%20substitution%20cipher.md) which uses a keyword to encrypt and decrypt messages.
 
 **How it works?**
 
 1. Each letter of the key specifies a different shift
-2. Same plaintext letter can encrypt to different [[Ciphertext]] letters
+2. Same plaintext letter can encrypt to different [Ciphertext](Ciphertext.md) letters
 3. Algorithm takes two inputs: message(plaintext) and key(password).
 4. Algorithm prepare key by repeating it to the message length.
 5. Then it intitialize empty result string.

--- a/Blog/Blog.md
+++ b/Blog/Blog.md
@@ -7,8 +7,8 @@ Articles are sorted from newest to the oldest ones
 - [[7. How I failed at writing a blog many times]]
 - [[6. Onboarding to coding]]
 - [[5. Exception Handling in C#]]
-- [[4. Historical cryptography algorithms]]
-- [[3. Caesar Cipher Implementation in C Sharp]]
+- [4. Historical cryptography algorithms](4.%20Historical%20cryptography%20algorithms.md)
+- [3. Caesar Cipher Implementation in C Sharp](3.%20Caesar%20Cipher%20Implementation%20in%20C%20Sharp.md)
 - [[2. How and Why I Moved My Blog from WordPress to Astro and Markdown]]
 - [[1. How Saying ‘I Don’t Know’ Can Make You a Better Software Engineer]]
 - [[0. Archived articles, migrated from previous blog]]

--- a/Blog/Why teaching kids how to program is not easy.md
+++ b/Blog/Why teaching kids how to program is not easy.md
@@ -19,4 +19,4 @@ And most importantly — patience to match their learning pace.
 
 Read more on Medium: <https://medium.com/@frodigo/why-teaching-kids-how-to-program-isnt-easy-50817bcd5af4>
 
-Learning roadmap: [[Programming for Kids]]
+Learning roadmap: [Programming for Kids](Programming%20for%20Kids.md)

--- a/Now/History/25-03-2025.md
+++ b/Now/History/25-03-2025.md
@@ -10,8 +10,8 @@ My son has repeatedly asked me what I do in my work, so I showed him some code a
 
 Connected resources:
 
-- [[Programming for Kids]]
-- [[Why teaching kids how to program is not easy]]
+- [Programming for Kids](Programming%20for%20Kids.md)
+- [Why teaching kids how to program is not easy](Why%20teaching%20kids%20how%20to%20program%20is%20not%20easy.md)
 
 ---
 
@@ -35,4 +35,4 @@ For most of last year, I couldn't run which was quite painful for me. Physically
 
 We're renovating our kitchen. We ordered new furniture and appliances, and I want to rewire the electricity and lay new tiles on the wall with my own hands. I'm in the preparation phase. The serious work starts soon!
 
-I wrote a little bit about this here: [[What well-known life laws I confirmed when I did a kitchen renovation]]
+I wrote a little bit about this here: [What well-known life laws I confirmed when I did a kitchen renovation](What%20well-known%20life%20laws%20I%20confirmed%20when%20I%20did%20a%20kitchen%20renovation.md)

--- a/Now/Now.md
+++ b/Now/Now.md
@@ -70,4 +70,4 @@ I look for contributors. Maybe you?
 
 Below you can find my historical now pages. Date along the title means a day when a page was moved to the history.
 
-- [[25-03-2025]]
+- [25-03-2025](25-03-2025.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Even when our world crumbles and we're forced into vibe coding at corporate jobs
 
 1. Independence over dependency
 2. Creation over consumption
-3. [[Progress over perfection]]
+3. Progress over perfection
 4. Open-source over closed-source
 5. Honesty over marketing BS
 6. Asynchronous collaboration over unproductive meetings
@@ -33,14 +33,14 @@ Even when our world crumbles and we're forced into vibe coding at corporate jobs
 ## What you can find here
 
 - README (this page)
-- [[About]] - in case if you want to read more about me
-- [[Now]] - describes what I am currently focusing on and what I am doing
-- [[Contact]] - contact information
-- [[Blog]] - (under development) my stories
-- [[Projects]] - (under development) shows my recent and current projects
-- [[Testimonials]] - here you can check what others say about me
-- [[Privacy policy]] - a page that clearly says that I don't use cookies and I don't collect any your data. You are safe in my garage
-- [[Atlas/README|Atlas]] - notes, learning and discovered knowledge
+- [About](About.md) - in case if you want to read more about me
+- [Now](Now.md) - describes what I am currently focusing on and what I am doing
+- [Contact](Contact.md) - contact information
+- [Blog](Blog.md) - (under development) my stories
+- [Projects](Projects.md) - (under development) shows my recent and current projects
+- [Testimonials](Testimonials.md) - here you can check what others say about me
+- [Privacy policy](Privacy%20policy.md) - a page that clearly says that I don't use cookies and I don't collect any your data. You are safe in my garage
+- [Atlas](Atlas/README.md) - notes, learning and discovered knowledge
 
 The best way to read content here is to use a navigation and explore content grouped by folders.
 
@@ -65,7 +65,7 @@ All you can find here is open source and available in two places:
 
 ### Licensing
 
-Information about how this repository is licensed is [[Licensing|here]].
+Information about how this repository is licensed is [here](Licensing.md).
 
 ### Contributing
 
@@ -75,4 +75,4 @@ I appreciate any help. Here's how you can help:
 - **Suggest ideas** by starting a discussion
 - **Submit pull requests** for bug fixes or new features
 
-More info about contributing is [[Contributing|here]]
+More info about contributing is [here](Contributing.md)


### PR DESCRIPTION
I realized that links doesn't work on Github and it was because in Obsidiad I used Wikilinks.
Changed Obsidian's config to start using 'classic' markdow links, edited MD files and from now links should work
on Github.