### PR TITLE
fix: fixed publishing to pypi workflow

### DIFF
--- a/.github/workflows/nitrodigest_publish.yml
+++ b/.github/workflows/nitrodigest_publish.yml
@@ -47,3 +47,4 @@ jobs:
 
         with:
           repository-url: ${{ inputs.environment == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          packages-dir: Projects/Nitrodigest/Cli/dist/


### PR DESCRIPTION
Added `packages-dir` to config. It should fix problem `FileNotFound`