### PR TITLE
fix: added missed dependencies to setuptools

### DIFF
--- a/Projects/Nitrodigest/setup.cfg
+++ b/Projects/Nitrodigest/setup.cfg
@@ -15,6 +15,10 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+install_requires =
+    requests>=2.28.0
+    pyyaml>=6.0
+    nltk>=3.9.1
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
I forgot to specify required dependencies that needs to be installed with nitrodigest. Added them to setup.cfg